### PR TITLE
bcm2835: Switch PWM source clock from osc to plld.

### DIFF
--- a/src/bcm2835.c
+++ b/src/bcm2835.c
@@ -1668,7 +1668,7 @@ void bcm2835_pwm_set_clock(uint32_t divisor)
 	bcm2835_delay(1); 
     /* set the clock divider and enable PWM clock */
     bcm2835_peri_write(bcm2835_clk + BCM2835_PWMCLK_DIV, BCM2835_PWM_PASSWRD | (divisor << 12));
-    bcm2835_peri_write(bcm2835_clk + BCM2835_PWMCLK_CNTL, BCM2835_PWM_PASSWRD | 0x11); /* Source=osc and enable */
+    bcm2835_peri_write(bcm2835_clk + BCM2835_PWMCLK_CNTL, BCM2835_PWM_PASSWRD | 0x16); /* Source=plld and enable */
 }
 
 void bcm2835_pwm_set_mode(uint8_t channel, uint8_t markspace, uint8_t enabled)


### PR DESCRIPTION
According to new plld source clock maximum frequency for PWM
increased from 9.6 Mhz to 250 Mhz.